### PR TITLE
Envia o id do produto para melhorar a ref. gerada

### DIFF
--- a/moloni/src/Controllers/Product.php
+++ b/moloni/src/Controllers/Product.php
@@ -151,7 +151,7 @@ class Product
         $this->reference = $this->product->get_sku();
 
         if (empty($this->reference)) {
-            $this->reference = Tools::createReferenceFromString($this->product->get_name());
+            $this->reference = Tools::createReferenceFromString($this->product->get_name(), $this->product->get_id());
         }
 
         return $this;


### PR DESCRIPTION
Melhora a referencia a ser única no caso de produtos com nomes similares e compridos dado à limitação de 30 caracteres na referencia do moloni.